### PR TITLE
BKND-10890 Fixed retry logic for MixpanelConsumer

### DIFF
--- a/fam_analytics_py/base/consumer.py
+++ b/fam_analytics_py/base/consumer.py
@@ -26,7 +26,7 @@ class BaseConsumer(Thread):
         # pause immediately after construction, we might set running to True in
         # run() *after* we set it to False in pause... and keep running forever.
         self.running = True
-        self.retries = 3
+        self.retries = 10
 
     def run(self):
         """Runs the consumer."""
@@ -48,7 +48,6 @@ class BaseConsumer(Thread):
             self.request(batch)
             success = True
         except Exception as e:
-            LOGGER.error(f"error uploading: {e}")
             success = False
             if self.on_error:
                 self.on_error(e, batch)

--- a/fam_analytics_py/mixpanel/consumer.py
+++ b/fam_analytics_py/mixpanel/consumer.py
@@ -1,3 +1,4 @@
+import time
 from dataclasses import dataclass, field
 from fam_analytics_py.base import BaseConsumer
 from fam_analytics_py.request import post
@@ -69,7 +70,7 @@ class MixpanelConsumer(BaseConsumer):
             if not payload:
                 continue
 
-            attempt = 0
+            attempt = 1
             while True:
                 try:
                     post(
@@ -80,3 +81,4 @@ class MixpanelConsumer(BaseConsumer):
                     attempt += 1
                     if attempt > self.retries:
                         raise
+                    time.sleep(0.1 * attempt)


### PR DESCRIPTION
Solves for calling of _segregate_batch with batch array without 'type' key in it's elements since they've been popped in the first attempt